### PR TITLE
Add option to configure proxy via env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test coverage lint vet
 
 build:
-	go build
+	export CGO_ENABLED=0; go build
 lint:
 	go fmt $(go list ./... | grep -v /vendor/)
 vet:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Flags:
   -v, --version            version for check_prometheus
 ```
 
+The check plugin respects the environment variables `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`.
+
 ### Health
 
 Checks the health or readiness status of the Prometheus server.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -3,14 +3,16 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/NETWAYS/check_prometheus/internal/client"
-	"github.com/NETWAYS/go-check"
-	"github.com/prometheus/common/config"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/NETWAYS/check_prometheus/internal/client"
+	"github.com/NETWAYS/go-check"
+	"github.com/prometheus/common/config"
 )
 
 type AlertConfig struct {
@@ -82,10 +84,13 @@ func (c *Config) NewClient() *client.Client {
 	}
 
 	var rt http.RoundTripper = &http.Transport{
-		TLSClientConfig:       tlsConfig,
-		IdleConnTimeout:       10 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 10 * time.Second,
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     tlsConfig,
 	}
 
 	// Using a Bearer Token for authentication


### PR DESCRIPTION
This extends the default RoundTripper with http.ProxyFromEnvironment so that the Env Variable for Proxy configuration can be used.

Fixes #2 