### PR TITLE
Fix health check for older Prometheus versions

### DIFF
--- a/cmd/health_test.go
+++ b/cmd/health_test.go
@@ -41,6 +41,15 @@ func TestHealthCmd(t *testing.T) {
 			expected: "[OK] - Prometheus Server is Healthy. | statuscode=200\n",
 		},
 		{
+			name: "health-ok-older-versions",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`Prometheus is Healthy.`))
+			})),
+			args:     []string{"run", "../main.go", "health"},
+			expected: "[OK] - Prometheus is Healthy. | statuscode=200\n",
+		},
+		{
 			name: "ready-ok",
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -70,12 +70,12 @@ func (c *Client) GetStatus(ctx context.Context, endpoint string) (returncode int
 	respBody := strings.TrimSpace(string(b))
 
 	// What we expect from the Prometheus Server
-	statusOk := "Prometheus Server is Healthy."
+	statusOk := "is Healthy."
 	if endpoint == "ready" {
-		statusOk = "Prometheus Server is Ready."
+		statusOk = "is Ready."
 	}
 
-	if resp.StatusCode == http.StatusOK && respBody == statusOk {
+	if resp.StatusCode == http.StatusOK && strings.Contains(respBody, statusOk) {
 		return check.OK, resp.StatusCode, respBody, err
 	}
 


### PR DESCRIPTION
 - The output string changed in newer versions, so the fix is to check only for the substring

Fixes #5 