### PR TITLE
Add option to set CLI flags via env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,23 @@ Available Commands:
   query       Checks the status of a Prometheus query
 
 Flags:
-  -H, --hostname string    Hostname of the Prometheus server (default "localhost")
+  -H, --hostname string    Hostname of the Prometheus server (CHECK_PROMETHEUS_HOSTNAME) (default "localhost")
   -p, --port int           Port of the Prometheus server (default 9090)
   -s, --secure             Use a HTTPS connection
-  -i, --insecure           Skip the verification of the server TLS certificate
-  -b, --bearer string      Specify the Bearer Token for server authentication
-  -u, --user string        Specify the user name and password for server authentication <user:password>
-      --ca-file string     Specify the CA File for TLS authentication
-      --cert-file string   Specify the Certificate File for TLS authentication
-      --key-file string    Specify the Key File for TLS authentication
+  -i, --insecure           Skip the verification of the server's TLS certificate
+  -b, --bearer string      Specify the Bearer Token for server authentication (CHECK_PROMETHEUS_BEARER)
+  -u, --user string        Specify the user name and password for server authentication <user:password> (CHECK_PROMETHEUS_BASICAUTH)
+      --ca-file string     Specify the CA File for TLS authentication (CHECK_PROMETHEUS_CA_FILE)
+      --cert-file string   Specify the Certificate File for TLS authentication (CHECK_PROMETHEUS_CERT_FILE)
+      --key-file string    Specify the Key File for TLS authentication (CHECK_PROMETHEUS_KEY_FILE)
   -t, --timeout int        Timeout in seconds for the CheckPlugin (default 30)
   -h, --help               help for check_prometheus
   -v, --version            version for check_prometheus
 ```
 
 The check plugin respects the environment variables `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`.
+
+Various flags can be set with environment variables, refer to the help to see which flags.
 
 ### Health
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -22,12 +22,12 @@ type AlertConfig struct {
 }
 
 type Config struct {
-	BasicAuth string
-	Bearer    string
-	CAFile    string
-	CertFile  string
-	KeyFile   string
-	Hostname  string
+	BasicAuth string `env:"CHECK_PROMETHEUS_BASICAUTH"`
+	Bearer    string `env:"CHECK_PROMETHEUS_BEARER"`
+	CAFile    string `env:"CHECK_PROMETHEUS_CA_FILE"`
+	CertFile  string `env:"CHECK_PROMETHEUS_CERT_FILE"`
+	KeyFile   string `env:"CHECK_PROMETHEUS_KEY_FILE"`
+	Hostname  string `env:"CHECK_PROMETHEUS_HOSTNAME"`
 	Port      int
 	Info      bool
 	Insecure  bool

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ func init() {
 
 	pfs := rootCmd.PersistentFlags()
 	pfs.StringVarP(&cliConfig.Hostname, "hostname", "H", "localhost",
-		"Hostname of the Prometheus server")
+		"Hostname of the Prometheus server (CHECK_PROMETHEUS_HOSTNAME)")
 	pfs.IntVarP(&cliConfig.Port, "port", "p", 9090,
 		"Port of the Prometheus server")
 	pfs.BoolVarP(&cliConfig.Secure, "secure", "s", false,
@@ -48,15 +48,15 @@ func init() {
 	pfs.BoolVarP(&cliConfig.Insecure, "insecure", "i", false,
 		"Skip the verification of the server's TLS certificate")
 	pfs.StringVarP(&cliConfig.Bearer, "bearer", "b", "",
-		"Specify the Bearer Token for server authentication")
+		"Specify the Bearer Token for server authentication (CHECK_PROMETHEUS_BEARER)")
 	pfs.StringVarP(&cliConfig.BasicAuth, "user", "u", "",
-		"Specify the user name and password for server authentication <user:password>")
+		"Specify the user name and password for server authentication <user:password> (CHECK_PROMETHEUS_BASICAUTH)")
 	pfs.StringVarP(&cliConfig.CAFile, "ca-file", "", "",
-		"Specify the CA File for TLS authentication")
+		"Specify the CA File for TLS authentication (CHECK_PROMETHEUS_CA_FILE)")
 	pfs.StringVarP(&cliConfig.CertFile, "cert-file", "", "",
-		"Specify the Certificate File for TLS authentication")
+		"Specify the Certificate File for TLS authentication (CHECK_PROMETHEUS_CERT_FILE)")
 	pfs.StringVarP(&cliConfig.KeyFile, "key-file", "", "",
-		"Specify the Key File for TLS authentication")
+		"Specify the Key File for TLS authentication (CHECK_PROMETHEUS_KEY_FILE)")
 	pfs.IntVarP(&Timeout, "timeout", "t", Timeout,
 		"Timeout in seconds for the CheckPlugin")
 
@@ -65,6 +65,8 @@ func init() {
 
 	help := rootCmd.HelpTemplate()
 	rootCmd.SetHelpTemplate(help + Copyright)
+
+	check.LoadFromEnv(&cliConfig)
 }
 
 func Usage(cmd *cobra.Command, _ []string) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/NETWAYS/check_prometheus
 go 1.21
 
 require (
-	github.com/NETWAYS/go-check v0.5.0
+	github.com/NETWAYS/go-check v0.6.0
 	github.com/prometheus/client_golang v1.17.0
 	github.com/prometheus/common v0.44.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/NETWAYS/go-check v0.5.0 h1:YahXTyveSOww3mTtKnvbsXZSk9kHi82mnvXHsNWx7AQ=
-github.com/NETWAYS/go-check v0.5.0/go.mod h1:3G1p9ZCv41UcKirl+nZWne8oKVPUY5HbtyjRwGgyw6A=
+github.com/NETWAYS/go-check v0.6.0 h1:/fbQ3oVii4tei6vF/nuJQ2JUerT2rHNr3XQMUFdGg3A=
+github.com/NETWAYS/go-check v0.6.0/go.mod h1:3G1p9ZCv41UcKirl+nZWne8oKVPUY5HbtyjRwGgyw6A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=


### PR DESCRIPTION
This PR adds the possibility to set CLI flags via env variables (currently only string variables)