### PR TITLE
add new parameter "URL" to access Prometheus behind reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Available Commands:
 Flags:
   -H, --hostname string    Hostname of the Prometheus server (CHECK_PROMETHEUS_HOSTNAME) (default "localhost")
   -p, --port int           Port of the Prometheus server (default 9090)
+  -U, --url string         URL/Path to append to the Promethes Hostname (default "/")
   -s, --secure             Use a HTTPS connection
   -i, --insecure           Skip the verification of the server's TLS certificate
   -b, --bearer string      Specify the Bearer Token for server authentication (CHECK_PROMETHEUS_BEARER)
@@ -161,6 +162,7 @@ CRITICAL - 6 Alerts: 3 Firing - 0 Pending - 3 Inactive
  | total=6 firing=3 pending=0 inactive=3
 
 ```
+
 #### Checking multiple alerts
 
 ```bash

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	CertFile  string `env:"CHECK_PROMETHEUS_CERT_FILE"`
 	KeyFile   string `env:"CHECK_PROMETHEUS_KEY_FILE"`
 	Hostname  string `env:"CHECK_PROMETHEUS_HOSTNAME"`
+	URL       string `env:"CHECK_PROMETHEUS_URL"`
 	Port      int
 	Info      bool
 	Insecure  bool
@@ -65,6 +66,7 @@ func (c *Config) NewClient() *client.Client {
 	u := url.URL{
 		Scheme: "http",
 		Host:   c.Hostname + ":" + strconv.Itoa(c.Port),
+		Path:   c.URL,
 	}
 
 	if c.Secure {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,6 +43,8 @@ func init() {
 		"Hostname of the Prometheus server (CHECK_PROMETHEUS_HOSTNAME)")
 	pfs.IntVarP(&cliConfig.Port, "port", "p", 9090,
 		"Port of the Prometheus server")
+	pfs.StringVarP(&cliConfig.URL, "url", "U", "/",
+		"URL/Path to append to the Promethes Hostname")
 	pfs.BoolVarP(&cliConfig.Secure, "secure", "s", false,
 		"Use a HTTPS connection")
 	pfs.BoolVarP(&cliConfig.Insecure, "insecure", "i", false,


### PR DESCRIPTION
Context: We have multiple Prometheus instances accessible behind a reverse proxy.

This add a new parameter `-U`/`--url` that allows to append an URL/a path behind "hostname:port".