### PR TITLE
ARM64 releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,7 @@ builds:
       - CGO_ENABLED=0
     goarch:
       - amd64
+      - arm64
     goos:
       - linux
       - windows
@@ -30,6 +31,7 @@ archives:
       {{- if eq .Os "windows" }}Windows{{ end }}
       {{- if eq .Os "darwin" }}Darwin{{ end }}
       {{- if eq .Arch "amd64" }}_x86_64{{ end }}
+      {{- if eq .Arch "arm64" }}_arm64{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Hello, I'm interested in using this check in my Icinga installation, but my vms are all Arm64, so I forked the repo and tryed to add the architecture on the goreleaser file.
The build actions worked without problems and I downloaded the Linux and Darwin bins; I've tested it in my Macmini M2 and a Debian 12 vm, and they worked fine. Unfortunately I can't test the Windows Arm64 release.
So if you want to merge this PR, I appreciate to use the Arm64 releases from your repo. In the meantime I've released the arm64 bins to start using it in my fork

Thanks
