### PR TITLE
Rework logic when there are no alerts defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,12 @@ Examples:
    | total=2 firing=1 pending=0 inactive=1
 
 Flags:
-  -h, --help           help for alert
-  -n, --name strings   The name of one or more specific alerts to check.
-                       This parameter can be repeated e.G.: '--name alert1 --name alert2'
-                       If no name is given, all alerts will be evaluated
- -P, --problems       Display only alerts which status is not inactive/OK
+  -h, --help                     help for alert
+  -n, --name strings             The name of one or more specific alerts to check.
+                                 This parameter can be repeated e.G.: '--name alert1 --name alert2'
+                                 If no name is given, all alerts will be evaluated
+  -T, --no-alerts-state string   State to assign when no alerts are found (0, 1, 2, 3, OK, WARNING, CRITICAL, UNKNOWN). If not set this defaults to OK (default "OK")
+  -P, --problems                 Display only alerts which status is not inactive/OK. Note that in combination with the --name flag this might result in no alerts being displayed
 ```
 
 #### Checking all defined alerts

--- a/cmd/alert_test.go
+++ b/cmd/alert_test.go
@@ -38,7 +38,7 @@ func TestAlertCmd(t *testing.T) {
 				w.Write([]byte(`{"status":"success","data":{"groups":[]}}`))
 			})),
 			args:     []string{"run", "../main.go", "alert"},
-			expected: "[UNKNOWN] - 0 Alerts: 0 Firing - 0 Pending - 0 Inactive\n\nexit status 3\n",
+			expected: "[OK] - No alerts defined\n",
 		},
 		{
 			name: "alert-none-with-problems",
@@ -47,7 +47,25 @@ func TestAlertCmd(t *testing.T) {
 				w.Write([]byte(`{"status":"success","data":{"groups":[]}}`))
 			})),
 			args:     []string{"run", "../main.go", "alert", "--problems"},
-			expected: "[UNKNOWN] - 0 Alerts: 0 Firing - 0 Pending - 0 Inactive\n\nexit status 3\n",
+			expected: "[OK] - No alerts defined\n",
+		},
+		{
+			name: "alert-none-with-no-state",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"status":"success","data":{"groups":[]}}`))
+			})),
+			args:     []string{"run", "../main.go", "alert", "--no-alerts-state", "3"},
+			expected: "[UNKNOWN] - No alerts defined\nexit status 3\n",
+		},
+		{
+			name: "alert-none-with-name",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"status":"success","data":{"groups":[]}}`))
+			})),
+			args:     []string{"run", "../main.go", "alert", "--name", "MyPreciousAlert"},
+			expected: "[UNKNOWN] - No such alert defined\nexit status 3\n",
 		},
 		{
 			name: "alert-default",

--- a/cmd/alert_test.go
+++ b/cmd/alert_test.go
@@ -32,6 +32,24 @@ type AlertTest struct {
 func TestAlertCmd(t *testing.T) {
 	tests := []AlertTest{
 		{
+			name: "alert-none",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"status":"success","data":{"groups":[]}}`))
+			})),
+			args:     []string{"run", "../main.go", "alert"},
+			expected: "[UNKNOWN] - 0 Alerts: 0 Firing - 0 Pending - 0 Inactive\n\nexit status 3\n",
+		},
+		{
+			name: "alert-none-with-problems",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"status":"success","data":{"groups":[]}}`))
+			})),
+			args:     []string{"run", "../main.go", "alert", "--problems"},
+			expected: "[UNKNOWN] - 0 Alerts: 0 Firing - 0 Pending - 0 Inactive\n\nexit status 3\n",
+		},
+		{
 			name: "alert-default",
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -15,12 +15,6 @@ import (
 	"github.com/prometheus/common/config"
 )
 
-type AlertConfig struct {
-	AlertName    []string
-	Group        []string
-	ProblemsOnly bool
-}
-
 type Config struct {
 	BasicAuth string `env:"CHECK_PROMETHEUS_BASICAUTH"`
 	Bearer    string `env:"CHECK_PROMETHEUS_BEARER"`
@@ -57,10 +51,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see https://www.gnu.org/licenses/.
 `
 
-var (
-	cliConfig      Config
-	cliAlertConfig AlertConfig
-)
+var cliConfig Config
 
 func (c *Config) NewClient() *client.Client {
 	u := url.URL{


### PR DESCRIPTION
I reworked to logic when no alerts are returned from the API.    
    
Changes default to OK, instead of UNKNOWN.

Added a check to see if the API response contains alert rules. If not, we exit early.
    
To add extra flexibility this also adds a `--no-alerts-state flag` that can be used to set the desired exit state when no alerts are found.

See #65 
