### PR TITLE
Add option to exlcude alerts from the results

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,12 +150,13 @@ Examples:
    | total=2 firing=1 pending=0 inactive=1
 
 Flags:
-  -h, --help                     help for alert
-  -n, --name strings             The name of one or more specific alerts to check.
-                                 This parameter can be repeated e.G.: '--name alert1 --name alert2'
-                                 If no name is given, all alerts will be evaluated
-  -T, --no-alerts-state string   State to assign when no alerts are found (0, 1, 2, 3, OK, WARNING, CRITICAL, UNKNOWN). If not set this defaults to OK (default "OK")
-  -P, --problems                 Display only alerts which status is not inactive/OK. Note that in combination with the --name flag this might result in no alerts being displayed
+      --exclude-alert stringArray  Alerts to ignore. Can be used multiple times and supports regex.
+  -h, --help                       help for alert
+  -n, --name strings               The name of one or more specific alerts to check.
+                                   This parameter can be repeated e.G.: '--name alert1 --name alert2'
+                                   If no name is given, all alerts will be evaluated
+  -T, --no-alerts-state string     State to assign when no alerts are found (0, 1, 2, 3, OK, WARNING, CRITICAL, UNKNOWN). If not set this defaults to OK (default "OK")
+  -P, --problems                   Display only alerts which status is not inactive/OK. Note that in combination with the --name flag this might result in no alerts being displayed
 ```
 
 #### Checking all defined alerts


### PR DESCRIPTION
This adds an option to exclude alerts from the results.
    
The use case behind this: sometimes you want to define
a so called Watchdog or DeadMansSwitch alert that is always
firing, in order to monitoring that the alerting is working.
    
When such a Watchdog is defined the list of all alerts will
always be Critical. Thus we add a flag to exclude certain alerts.

See #61  

I want to tackle the issue in two steps, this is the first. The second is a feature to specify the expected exit code.