### PR TITLE
Use --no-alerts-state in PartialCheckResult

### DIFF
--- a/cmd/alert.go
+++ b/cmd/alert.go
@@ -192,6 +192,9 @@ inactive = 0`,
 		// When there are no alerts we add an empty PartialResult just to have consistent output
 		if len(overall.PartialResults) == 0 {
 			sc := result.NewPartialResult()
+			// We already make sure it's valid
+			//nolint: errcheck
+			sc.SetDefaultState(noAlertsState)
 			sc.Output = "No alerts retrieved"
 			overall.AddSubcheck(sc)
 		}

--- a/cmd/alert_test.go
+++ b/cmd/alert_test.go
@@ -165,7 +165,7 @@ exit status 2
 				w.WriteHeader(http.StatusOK)
 				w.Write(loadTestdata(alertTestDataSet2))
 			})),
-			args: []string{"run", "../main.go", "alert", "--name", "NoSuchAlert"},
+			args: []string{"run", "../main.go", "alert", "--name", "NoSuchAlert", "-T", "3"},
 			expected: `[UNKNOWN] - 0 Alerts: 0 Firing - 0 Pending - 0 Inactive
 \_ [UNKNOWN] No alerts retrieved
 |total=0 firing=0 pending=0 inactive=0
@@ -179,7 +179,7 @@ exit status 3
 				w.WriteHeader(http.StatusOK)
 				w.Write(loadTestdata(alertTestDataSet2))
 			})),
-			args: []string{"run", "../main.go", "alert", "--name", "InactiveAlert", "--problems"},
+			args: []string{"run", "../main.go", "alert", "--name", "InactiveAlert", "--problems", "-T", "3"},
 			expected: `[UNKNOWN] - 0 Alerts: 0 Firing - 0 Pending - 0 Inactive
 \_ [UNKNOWN] No alerts retrieved
 |total=0 firing=0 pending=0 inactive=0


### PR DESCRIPTION
Now users can define what state is returned when
there is an empty list.

This is somewhat "breaking" since it changes default behavior. 
But the benefit is more flexibility and consistency 

Fixes #94 