### PR TITLE
Allow password with colons

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -96,7 +96,7 @@ func (c *Config) NewClient() *client.Client {
 
 	// Using a BasicAuth for authentication
 	if c.BasicAuth != "" {
-		s := strings.Split(c.BasicAuth, ":")
+		s := strings.SplitN(c.BasicAuth, ":", 2)
 		if len(s) != 2 {
 			check.ExitError(errors.New("specify the user name and password for server authentication <user:password>"))
 		}


### PR DESCRIPTION
fixes #130 

If a password (part of the `--user` option) contains one or more colons (`:`), it was split at _every_ colon and only the first part of the password was used.
This made sense since the basic auth string is `Username:Password` but prevents the usage of colons in the password (and also the user name, but whoever puts colons in there may just suffer the consequences).

This patch changes the behaviour to only split at the first colon.

@tectumopticum: Care to try this?